### PR TITLE
Fix: With "noCalendar", it's not necessary to set month and year.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -527,14 +527,14 @@ function FlatpickrInstance(
       self.config.errorHandler(ex);
     }
 
-    if (triggerChange && self.currentYear !== oldYear) {
+    if (triggerChange && self.currentYear !== oldYear && !self.config.noCalendar) {
       triggerEvent("onYearChange");
       buildMonthSwitch();
     }
 
     if (
       triggerChange &&
-      (self.currentYear !== oldYear || self.currentMonth !== oldMonth)
+      (self.currentYear !== oldYear || self.currentMonth !== oldMonth && !self.config.noCalendar)
     ) {
       triggerEvent("onMonthChange");
     }
@@ -965,6 +965,8 @@ function FlatpickrInstance(
       );
     };
 
+    if (self.config.noCalendar) return
+    
     self.monthsDropdownContainer.tabIndex = -1;
 
     self.monthsDropdownContainer.innerHTML = "";


### PR DESCRIPTION
Hi,

When I use `flatpickrInstance.setDate(valueDayjs.toDate(), true)` with a config that contains "noCalendar:true", 
the method "jumToDate" calls  "buildMonthSwitch" which try to set year and month.
![image](https://github.com/kodaicoder/flatpickr_plus/assets/10244725/bca903c8-0556-472a-8ea1-01328a080c91)


But "monthsDropdownContainer" doesn't exist in "TimePicker" mode.
![image](https://github.com/kodaicoder/flatpickr_plus/assets/10244725/a95f993e-82fc-4448-9363-b9f2425054a7)
 
Regards,
Franck